### PR TITLE
chall05 - pcuadrad

### DIFF
--- a/chall05/pcuadrad.c
+++ b/chall05/pcuadrad.c
@@ -17,7 +17,7 @@ int     ft_ie_except_after_c(char *str)
 {
     int coincidence;
 
-    if (((coincidence = find(str, "ei")) != -1 && (coincidence == 0 || str[coincidence - 1] != 'c')) ||
+    if ((!str) || ((coincidence = find(str, "ei")) != -1 && (coincidence == 0 || str[coincidence - 1] != 'c')) ||
         ((coincidence = find(str, "ie")) != -1 && str[coincidence - 1] == 'c'))
         return (0);
     return (1);

--- a/chall05/pcuadrad.c
+++ b/chall05/pcuadrad.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+int     find(char *str, char *to_find)
+{
+    int     i;
+    int     j;
+
+    i = -1;
+    while (str[++i] && (j = -1))
+        while (to_find[++j] && str[i + j] && str[i + j] == to_find[j])
+            if (!to_find[j + 1])
+                return (i);
+    return (-1);
+}
+
+int     ft_ie_except_after_c(char *str)
+{
+    int coincidence;
+
+    if (((coincidence = find(str, "ei")) != -1 && (coincidence == 0 || str[coincidence - 1] != 'c')) ||
+        ((coincidence = find(str, "ie")) != -1 && str[coincidence - 1] == 'c'))
+        return (0);
+    return (1);
+}


### PR DESCRIPTION
Function prototype:
int     ft_ie_except_after_c(char *str)
Return 1: the rule "I before E except after C" is followed.
Return 0: the rule is not followed.

I use an auxiliar function called find that returns the position where I find the string "ei" or "ie" respectively, if it doesn't find it it returns -1.
In the case of "ei" I check that the previous character to the match is not a 'c', in that case the rule is not followed and I return 0. In the case that "ei" is at the beginning of the word, that is to say that the position of the coincidence is 0, I do the same since the rule is not followed.
In the case of "ie" I do the opposite, if the previous character to the match is a 'c' I return 0 since the rule is not followed.