### PR TITLE
vde-dios.c

### DIFF
--- a/chall11/vde-dios.c
+++ b/chall11/vde-dios.c
@@ -14,7 +14,7 @@ char *ft_goto_parser(const char *code)
     long n_line = 0;
     char *input = strdup(code);
 
-    next = strtok(input, "\n");
+    next = strtok_r(input, "\n", &input);
     while (next)
     {
         if (!strtol(next, &statement, 10) && errno == EINVAL)
@@ -25,15 +25,15 @@ char *ft_goto_parser(const char *code)
                 return (strdup("Infinite loop !"));
             else
             {
-                next = strtok(NULL, "\n");
+                next = strtok_r(input, "\n", &input);
                 while(!strstr(next, statement))
-                    next = strtok(NULL, "\n");
+                    next = strtok_r(input, "\n", &input);
             }
         }
         else
         {
             n_line = strtol(next, &statement, 10);
-            word = strtok(statement, " ");
+            word = strtok_r(statement, " ", &statement);
             while(word)
             {
                 while(isspace(*word))
@@ -41,9 +41,9 @@ char *ft_goto_parser(const char *code)
                 asprintf(&output, "%s%s%s", tmp ? tmp: "", tmp ? " ": "", word);
                 free(tmp);
                 tmp = output;
-                word = strtok(NULL, "\n");
+                word = strtok_r(statement, " ", &statement);
             }
-            next = strtok(NULL, "\n");
+        next = strtok_r(input, "\n", &input);
         }
     }
     free(input);

--- a/chall11/vde-dios.c
+++ b/chall11/vde-dios.c
@@ -8,7 +8,7 @@ char *ft_goto_parser(const char *code)
 {
     char *next;
     char *word;
-    char *statement = NULL;
+    char *aux = NULL;
     char *output = NULL;
     char *tmp = NULL;
     long n_line = 0;
@@ -17,33 +17,36 @@ char *ft_goto_parser(const char *code)
     next = strtok_r(input, "\n", &input);
     while (next)
     {
-        if (!strtol(next, &statement, 10) && errno == EINVAL)
+        if (!isdigit(*next))
         {
-            while(!isdigit(*statement))
-                statement++;
-            if (n_line >= atoi(statement))
-                return (strdup("Infinite loop !"));
-            else
+            aux = next;
+            while(!isdigit(*aux))
+                aux++;
+            next = strtok_r(input, "\n", &input);
+            while(!strstr(next, aux))
             {
                 next = strtok_r(input, "\n", &input);
-                while(!strstr(next, statement))
-                    next = strtok_r(input, "\n", &input);
+                if (!next)
+                    return (strdup("Infinite loop !"));
             }
         }
         else
         {
-            n_line = strtol(next, &statement, 10);
-            word = strtok_r(statement, " ", &statement);
+            while (isdigit(*next))
+                next++;
+            word = strtok_r(next, " ", &next);
             while(word)
             {
-                while(isspace(*word))
+                while(*word && isspace(*word))
                     word++;
-                asprintf(&output, "%s%s%s", tmp ? tmp: "", tmp ? " ": "", word);
-                free(tmp);
-                tmp = output;
-                word = strtok_r(statement, " ", &statement);
+                if (*word){
+                    asprintf(&output, "%s%s%s", tmp ? tmp: "", tmp ? " ": "", word);
+                    free(tmp);
+                    tmp = output;
+                }
+                word = strtok_r(next, " ", &next);
             }
-        next = strtok_r(input, "\n", &input);
+            next = strtok_r(input, "\n", &input);
         }
     }
     free(input);

--- a/chall11/vde-dios.c
+++ b/chall11/vde-dios.c
@@ -1,0 +1,50 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+
+char *ft_goto_parser(const char *code)
+{
+    char *next;
+    char *word;
+    char *statement = NULL;
+    char *output = NULL;
+    char *tmp = NULL;
+    long n_line = 0;
+    char *input = strdup(code);
+    next = strtok(input, "\n");
+    while (next)
+    {
+        if (!strtol(next, &statement, 10) && errno == EINVAL)
+        {
+            while(!isdigit(*statement))
+                statement++;
+            if (n_line >= atoi(statement))
+                return (strdup("Infinite loop !"));
+            else
+            {
+                next = strtok(NULL, "\n");
+                while(!strstr(next, statement))
+                    next = strtok(NULL, "\n");
+            }
+        }
+        else
+        {
+            n_line = strtol(next, &statement, 10);
+            word = strtok(statement, " ");
+            while(word)
+            {
+                while(isspace(*word))
+                    word++;
+                asprintf(&output, "%s%s%s", tmp ? tmp: "", tmp ? " ": "", word);
+                free(tmp);
+                tmp = output;
+                word = strtok(NULL, "\n");
+            }
+            next = strtok(NULL, "\n");
+        }
+    }
+    free(input);
+    return (output);
+}

--- a/chall11/vde-dios.c
+++ b/chall11/vde-dios.c
@@ -13,6 +13,7 @@ char *ft_goto_parser(const char *code)
     char *tmp = NULL;
     long n_line = 0;
     char *input = strdup(code);
+
     next = strtok(input, "\n");
     while (next)
     {


### PR DESCRIPTION
### SOLUTION

With `strtok` the string is split using `\n` as a delimiter. After that, each sentence is analysed. First number is checked, if we get an `errno` it means we have a goto sentence. In this case we look for the matching line using `strstr` to encounter the following line.

For the output string, `asprintf` function is used. Each sentence is split with `strtok` and properly contatenated.

The function exits with no leaks apart from the returned string. All output strings are allocated and there is no string literals involved.